### PR TITLE
Fix PKGBUILD to work on current Arch Linux installs

### DIFF
--- a/packaging/ArchLinux/PKGBUILD
+++ b/packaging/ArchLinux/PKGBUILD
@@ -5,7 +5,7 @@ pkgrel=1
 pkgdesc="Designer, GUI builder, and RAD tool for wxWidgets"
 arch=(i686 x86_64)
 license=('GPL')
-depends=('wxgtk')
+depends=('wxgtk3')
 makedepends=('git')
 provides=('wxformbuilder')
 conflicts=('wxformbuilder')
@@ -36,7 +36,7 @@ build() {
   #
   mkdir build
   cd build
-  cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+  cmake -DwxWidgets_CONFIG_EXECUTABLE=/usr/bin/wx-config-gtk3 -DCMAKE_INSTALL_PREFIX=/usr ..
   make -j4
 }
 


### PR DESCRIPTION
I just tried to build this on Arch Linux and had to make a few tweaks to the PKGBUILD to get it to work.

Looks like this change will have to be made across all branches; I'm not sure what your policy is on that but the same change should be sufficient everywhere.